### PR TITLE
Update locale.format at stopwatch.py

### DIFF
--- a/stopwatch.py
+++ b/stopwatch.py
@@ -337,7 +337,7 @@ class OneWatchView():
         return False
 
     def _format(self, t):
-        return locale.format('%.2f', max(0, t))
+        return locale.format_string('%.2f', max(0, t))
 
     def _update_label(self, string, ev):
         self._time_label.set_text(string)


### PR DESCRIPTION
Replace old function in favor of locale.format_string to work with python3.12/trisquel 12